### PR TITLE
Trailer transcodes, new splitting method

### DIFF
--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -759,6 +759,11 @@ export default class Scene {
                 options: options.selectOptions,
               },
             ])
+            .videoCodec("libx264")
+            .addOption("-preset", "veryslow")
+            .addOption("-movflags", "frag_keyframe+empty_moov+faststart")
+            .addOption("-crf", "18")
+            .size("?x360")
             .output(options.output)
             .noAudio()
             .run();


### PR DESCRIPTION
I liked your trailer branch, this was something I was planning on contributing myself too!

I made a couple of changes:

- Trailers are transcoded to MP4 with some web playing improvements. We could consider transcoding to WebM too, but since MP4 works pretty much everywhere, I think this is a "good enough" solution for scene trailers
- Trailers are shrunk to 360px height, since they are only shown on scene cards, no point in showing a full 1080p/4K/whatever resolution file
- Added `veryslow` preset, since it's not that critical to get the trailers super quickly, at least we can try and make them as small as possible.

The splitting method I used is more subjective.  I used the same method as popular tube sites do, which is:
- Split the video in 0.8 - 1.5 second chunks
- Trailer length is usually between 6 to 20 seconds

So now it does 1.2 second splits, with maximum trailer length of 12 seconds, kinda the average of what tube sites do. This method creates shorter, more varied segments from the video.

But again, this method is subjective, you are free to use it or not :) 
